### PR TITLE
Add CI and Release workflow (v20.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         build-output: ${{ env.BUILD_OUTPUT }}
 
     - name: Download docker cli
-      uses: WAGO/docker-actions/download-release-asset@feat/oelh/download-artifact
+      uses: WAGO/docker-actions/download-release-asset@release/v1.0
       with:
         repository: WAGO/docker-cli
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,8 +248,9 @@ jobs:
         include:
         - arch: amd64
           platform: linux/amd64
-        - arch: arm32v7
-          platform: linux/arm/v7
+# FIXME: Temporary disabled, while running under QEMU - a baremetal runner is needed to avoid false-positives
+#        - arch: arm32v7
+#          platform: linux/arm/v7
       
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,22 @@ jobs:
         project-version: ${{ env.VERSION }}
         build-output: ${{ env.BUILD_OUTPUT }}
 
+    - name: Download docker cli
+      uses: WAGO/docker-actions/download-release-asset@feat/oelh/download-artifact
+      with:
+        repository: WAGO/docker-cli
+        token: ${{ secrets.GITHUB_TOKEN }}
+        download-url-filter: ${{ steps.docker-make.outputs.target-platform-id }}
+
     - name: Create bundle
       id: create-bundle
       env:
         BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
       run: |
-        bundle_archive_name="dockerd-static-${BUNDLE_PLATFORM}.tar"
+        bundle_archive_name="docker-static-${BUNDLE_PLATFORM}.tar"
         bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
         build_output="${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${build_output}" -xzvf "docker-cli-"*".tar.gz"
         tar -C "${build_output}" -cvf "${bundle_archive}" .
         echo "::set-output name=input-path::${build_output}"
         echo "::set-output name=archive::${bundle_archive}"
@@ -299,7 +307,7 @@ jobs:
         BUNDLE_PLATFORM: ${{ steps.set-artifact-info.outputs.platform-id }}
       run: |
         echo "BUNDLE_PLATFORM=${BUNDLE_PLATFORM}" >> "${GITHUB_ENV}"
-        echo "BUNDLE_ARCHIVE_NAME=dockerd-static-${BUNDLE_PLATFORM}.tar" >> "${GITHUB_ENV}"
+        echo "BUNDLE_ARCHIVE_NAME=docker-static-${BUNDLE_PLATFORM}.tar" >> "${GITHUB_ENV}"
 
     - name: Download bundle
       uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,13 @@ jobs:
       id: create-bundle
       env:
         BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
+        TARGET_PLATFORM: ${{ matrix.platform }}
       run: |
         bundle_archive_name="dockerd-cross-${BUNDLE_PLATFORM}.tar"
         bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
-        tar -C "${BUILD_OUTPUT}/cross/${{ matrix.platform }}" -cvf "${bundle_archive}" .
+        build_output="${BUILD_OUTPUT}/cross/${TARGET_PLATFORM}"
+        tar -C "${build_output}" -cvf "${bundle_archive}" .
+        echo "::set-output name=input-path::${build_output}"
         echo "::set-output name=archive::${bundle_archive}"
         echo "::set-output name=archive-name::${bundle_archive_name}"
 
@@ -136,6 +139,12 @@ jobs:
         name: ${{ steps.create-bundle.outputs.archive-name }}
         path: ${{ steps.create-bundle.outputs.archive }}
         retention-days: 7
+
+    - name: Print artifact version informations
+      env:
+        BUNDLE_INPUT_PATH: ${{ steps.create-bundle.outputs.input-path }}
+      run: |
+        "${BUNDLE_INPUT_PATH}/dockerd" --version
 
   build-static-binary:
   
@@ -177,7 +186,9 @@ jobs:
       run: |
         bundle_archive_name="dockerd-static-${BUNDLE_PLATFORM}.tar"
         bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
-        tar -C "${BUILD_OUTPUT}/binary-daemon" -cvf "${bundle_archive}" .
+        build_output="${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${build_output}" -cvf "${bundle_archive}" .
+        echo "::set-output name=input-path::${build_output}"
         echo "::set-output name=archive::${bundle_archive}"
         echo "::set-output name=archive-name::${bundle_archive_name}"
 
@@ -187,6 +198,14 @@ jobs:
         name: ${{ steps.create-bundle.outputs.archive-name }}
         path: ${{ steps.create-bundle.outputs.archive }}
         retention-days: 7
+
+    - name: Print artifact version informations
+      env:
+        BUNDLE_INPUT_PATH: ${{ steps.create-bundle.outputs.input-path }}
+      run: |
+        "${BUNDLE_INPUT_PATH}/runc" --version
+        "${BUNDLE_INPUT_PATH}/containerd" --version
+        "${BUNDLE_INPUT_PATH}/dockerd" --version
 
   build-dynamic-binary:
   
@@ -229,7 +248,9 @@ jobs:
       run: |
         bundle_archive_name="dockerd-dynamic-${BUNDLE_PLATFORM}.tar"
         bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
-        tar -C "${BUILD_OUTPUT}/dynbinary-daemon" -cvf "${bundle_archive}" .
+        build_output="${BUILD_OUTPUT}/dynbinary-daemon"
+        tar -C "${build_output}" -cvf "${bundle_archive}" .
+        echo "::set-output name=input-path::${build_output}"
         echo "::set-output name=archive::${bundle_archive}"
         echo "::set-output name=archive-name::${bundle_archive_name}"
 
@@ -291,12 +312,6 @@ jobs:
         mkdir -p "${BUILD_OUTPUT}/binary-daemon"
         tar -C "${BUILD_OUTPUT}/binary-daemon" -xvf "${BUILD_OUTPUT}/${BUNDLE_ARCHIVE_NAME}"
 
-    - name: Print version information
-      run: |
-        "${BUILD_OUTPUT}/binary-daemon/runc" --version
-        "${BUILD_OUTPUT}/binary-daemon/containerd" --version
-        "${BUILD_OUTPUT}/binary-daemon/dockerd" version
-
     - name: Make test-unit
       id: docker-make
       uses: WAGO/docker-actions/docker-make@release/v1.0
@@ -325,14 +340,14 @@ jobs:
         report_output="${BUILD_OUTPUT}/junit-reports/${BUNDLE_PLATFORM}"
         mkdir -p "$report_output"
         cp "${BUILD_OUTPUT}"/junit-report*.xml "$report_output"
-        echo "::set-output name=report-output::${report_output}"
+        echo "::set-output name=input-path::${report_output}"
 
     - name: Upload test results
       uses: actions/upload-artifact@v2
       if: always()
       with:
         name: dockerd-test-results
-        path: ${{ steps.copy-test-results.outputs.report-output }}
+        path: ${{ steps.copy-test-results.outputs.input-path }}
         retention-days: 7
 
   publish-test-results:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ env:
   DOCKER_EXPERIMENTAL: 1
   DOCKER_GRAPHDRIVER: overlay2
   BUILDKIT_PROGRESS: plain
-  BASE_DEBIAN_DISTRO: buster
-  GOLANG_VERSION: 1.16.7
+  BASE_DEBIAN_DISTRO: stretch
+  GO_VERSION: 1.16.7
   APT_MIRROR: cdn-fastly.deb.debian.org
   CHECK_CONFIG_COMMIT: 78405559cfe5987174aa2cb6463b9b2c1b917255
   TESTDEBUG: 0
@@ -48,7 +48,7 @@ jobs:
       id: setup-docker-make
       uses: WAGO/docker-actions/setup-docker-make@release/v1.0
       with:
-        golang-version: ${{ env.GOLANG_VERSION }}
+        golang-version: ${{ env.GO_VERSION }}
         base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
         host-arch: ${{ matrix.arch }}
         target-platform: ${{ matrix.platform }}
@@ -111,7 +111,7 @@ jobs:
       with:
         targets: |
           cross
-        golang-version: ${{ env.GOLANG_VERSION }}
+        golang-version: ${{ env.GO_VERSION }}
         base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
         host-arch: ${{ matrix.arch }}
         target-platform: ${{ matrix.platform }}
@@ -171,7 +171,7 @@ jobs:
       with:
         targets: |
           binary
-        golang-version: ${{ env.GOLANG_VERSION }}
+        golang-version: ${{ env.GO_VERSION }}
         base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
         host-arch: ${{ matrix.arch }}
         target-platform: ${{ matrix.platform }}
@@ -252,7 +252,7 @@ jobs:
       with:
         targets: |
           dynbinary
-        golang-version: ${{ env.GOLANG_VERSION }}
+        golang-version: ${{ env.GO_VERSION }}
         base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
         host-arch: ${{ matrix.arch }}
         target-platform: ${{ matrix.platform }}
@@ -337,7 +337,7 @@ jobs:
       with:
         targets: |
           test-unit
-        golang-version: ${{ env.GOLANG_VERSION }}
+        golang-version: ${{ env.GO_VERSION }}
         base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
         host-arch: ${{ matrix.arch }}
         target-platform: ${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           platform: linux/arm/v7
       
     runs-on: ubuntu-latest
+    if: false == true
     needs:
       - build-cache
 
@@ -199,6 +200,7 @@ jobs:
           platform: linux/arm/v7
       
     runs-on: ubuntu-latest
+    if: false == true
     needs:
       - build-cache
 
@@ -246,9 +248,8 @@ jobs:
         include:
         - arch: amd64
           platform: linux/amd64
-# FIXME: disabled tests for 32bit, while support seems to be missing on 64bit (default) github action runners
-#        - arch: arm32v7
-#          platform: linux/arm/v7
+        - arch: arm32v7
+          platform: linux/arm/v7
       
     runs-on: ubuntu-latest
     needs:
@@ -260,6 +261,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Set up kernel modules
+      run: sudo modprobe ip6table_filter
 
     - name: Set artifact information
       id: set-artifact-info
@@ -286,8 +290,11 @@ jobs:
         mkdir -p "${BUILD_OUTPUT}/binary-daemon"
         tar -C "${BUILD_OUTPUT}/binary-daemon" -xvf "${BUILD_OUTPUT}/${BUNDLE_ARCHIVE_NAME}"
 
-    - name: Set up kernel modules
-      run: sudo modprobe ip6table_filter
+    - name: Print version information
+      run: |
+        "${BUILD_OUTPUT}/binary-daemon/runc" --version
+        "${BUILD_OUTPUT}/binary-daemon/containerd" --version
+        "${BUILD_OUTPUT}/binary-daemon/dockerd" version
 
     - name: Make test-unit
       id: docker-make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,349 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/**'
+  pull_request:
+    branches: 
+      - master
+      - 'release/**'
+
+env:
+  PLATFORM: Docker Engine - WAGO (Community)
+  DEFAULT_PRODUCT_LICENSE: Community Engine
+  DOCKER_GITCOMMIT: ${{ github.sha }}
+  DOCKER_EXPERIMENTAL: 1
+  DOCKER_GRAPHDRIVER: overlay2
+  BUILDKIT_PROGRESS: plain
+  BASE_DEBIAN_DISTRO: buster
+  GOLANG_VERSION: 1.16.7
+  APT_MIRROR: cdn-fastly.deb.debian.org
+  CHECK_CONFIG_COMMIT: 78405559cfe5987174aa2cb6463b9b2c1b917255
+  TESTDEBUG: 0
+  TIMEOUT: 120m
+  BUILD_OUTPUT: bundles
+  VERSION: '20.10-dev'
+
+jobs:
+  build-cache:
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+        - arch: arm32v7
+          platform: linux/arm/v7
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up node for Docker make
+      id: setup-docker-make
+      uses: WAGO/docker-actions/setup-docker-make@release/v1.0
+      with:
+        golang-version: ${{ env.GOLANG_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        project-version: ${{ env.VERSION }}
+
+    - name: Build cache image layers
+      uses: docker/build-push-action@v2
+      with:
+        target: binary-base
+        context: .
+        push: false
+        tags: dockerd-dev:${{ github.sha }}
+        cache-from: type=local,src=${{ steps.setup-docker-make.outputs.buildx-cache }}
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        platforms: |
+          ${{ matrix.platform }}
+        build-args: |
+          APT_MIRROR
+          PLATFORM
+          DEFAULT_PRODUCT_LICENSE
+          DOCKER_GITCOMMIT
+          VERSION=${{ steps.setup-docker-make.outputs.version }}
+          GOLANG_IMAGE=${{ steps.setup-docker-make.outputs.golang-imageref }}
+        load: true
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      env:
+        BUILDX_CACHE: ${{ steps.setup-docker-make.outputs.buildx-cache }}
+      run: |
+        rm -rf "${BUILDX_CACHE}"
+        mv /tmp/.buildx-cache-new "${BUILDX_CACHE}"
+    
+  build-cross-binary:
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+        - arch: amd64
+          platform: linux/arm/v7
+      
+    runs-on: ubuntu-latest
+    needs:
+      - build-cache
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Make cross
+      id: docker-make
+      uses: WAGO/docker-actions/docker-make@release/v1.0
+      with:
+        targets: |
+          cross
+        golang-version: ${{ env.GOLANG_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        project-version: ${{ env.VERSION }}
+        build-output: ${{ env.BUILD_OUTPUT }}
+
+    - name: Create bundle
+      id: create-bundle
+      env:
+        BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
+      run: |
+        bundle_archive_name="dockerd-cross-${BUNDLE_PLATFORM}.tar"
+        bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
+        tar -C "${BUILD_OUTPUT}/cross/${{ matrix.platform }}" -cvf "${bundle_archive}" .
+        echo "::set-output name=archive::${bundle_archive}"
+        echo "::set-output name=archive-name::${bundle_archive_name}"
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.create-bundle.outputs.archive-name }}
+        path: ${{ steps.create-bundle.outputs.archive }}
+        retention-days: 7
+
+  build-static-binary:
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+        - arch: arm32v7
+          platform: linux/arm/v7
+      
+    runs-on: ubuntu-latest
+    needs:
+      - build-cache
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Make binary
+      id: docker-make
+      uses: WAGO/docker-actions/docker-make@release/v1.0
+      with:
+        targets: |
+          binary
+        golang-version: ${{ env.GOLANG_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        project-version: ${{ env.VERSION }}
+        build-output: ${{ env.BUILD_OUTPUT }}
+
+    - name: Create bundle
+      id: create-bundle
+      env:
+        BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
+      run: |
+        bundle_archive_name="dockerd-static-${BUNDLE_PLATFORM}.tar"
+        bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
+        tar -C "${BUILD_OUTPUT}/binary-daemon" -cvf "${bundle_archive}" .
+        echo "::set-output name=archive::${bundle_archive}"
+        echo "::set-output name=archive-name::${bundle_archive_name}"
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.create-bundle.outputs.archive-name }}
+        path: ${{ steps.create-bundle.outputs.archive }}
+        retention-days: 7
+
+  build-dynamic-binary:
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+        - arch: arm32v7
+          platform: linux/arm/v7
+      
+    runs-on: ubuntu-latest
+    needs:
+      - build-cache
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Make dynamic binary
+      id: docker-make
+      uses: WAGO/docker-actions/docker-make@release/v1.0
+      with:
+        targets: |
+          dynbinary
+        golang-version: ${{ env.GOLANG_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        project-version: ${{ env.VERSION }}
+        build-output: ${{ env.BUILD_OUTPUT }}
+
+    - name: Create bundle
+      id: create-bundle
+      env:
+        BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
+      run: |
+        bundle_archive_name="dockerd-dynamic-${BUNDLE_PLATFORM}.tar"
+        bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
+        tar -C "${BUILD_OUTPUT}/dynbinary-daemon" -cvf "${bundle_archive}" .
+        echo "::set-output name=archive::${bundle_archive}"
+        echo "::set-output name=archive-name::${bundle_archive_name}"
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.create-bundle.outputs.archive-name }}
+        path: ${{ steps.create-bundle.outputs.archive }}
+        retention-days: 7
+
+  unit-test:
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+# FIXME: disabled tests for 32bit, while support seems to be missing on 64bit (default) github action runners
+#        - arch: arm32v7
+#          platform: linux/arm/v7
+      
+    runs-on: ubuntu-latest
+    needs:
+      - build-static-binary
+    
+    env:
+      TEST_SKIP_INTEGRATION_CLI: 1
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set artifact information
+      id: set-artifact-info
+      uses: WAGO/docker-actions/artifact-info@release/v1.0
+      with:
+        version: ${{ env.VERSION }}
+        platform: ${{ matrix.platform }}
+
+    - name: Set bundle meta information
+      env:
+        BUNDLE_PLATFORM: ${{ steps.set-artifact-info.outputs.platform-id }}
+      run: |
+        echo "BUNDLE_PLATFORM=${BUNDLE_PLATFORM}" >> "${GITHUB_ENV}"
+        echo "BUNDLE_ARCHIVE_NAME=dockerd-static-${BUNDLE_PLATFORM}.tar" >> "${GITHUB_ENV}"
+
+    - name: Download bundle
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ env.BUNDLE_ARCHIVE_NAME }}
+        path: ${{ env.BUILD_OUTPUT }}
+
+    - name: Extract bundle
+      run: |
+        mkdir -p "${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${BUILD_OUTPUT}/binary-daemon" -xvf "${BUILD_OUTPUT}/${BUNDLE_ARCHIVE_NAME}"
+
+    - name: Set up kernel modules
+      run: sudo modprobe ip6table_filter
+
+    - name: Make test-unit
+      id: docker-make
+      uses: WAGO/docker-actions/docker-make@release/v1.0
+      with:
+        targets: |
+          test-unit
+        golang-version: ${{ env.GOLANG_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        buildx-driver-opts: |
+          network=host
+        buildx-build-args: |
+          --load
+        make-args: |
+          DOCKER_IMAGE=dockerd-dev:${{ github.sha }}
+          KEEPBUNDLE=1
+        project-version: ${{ env.VERSION }}
+        build-output: ${{ env.BUILD_OUTPUT }}
+
+    - name: Copy test results
+      id: copy-test-results
+      if: always()
+      run: |
+        report_output="${BUILD_OUTPUT}/junit-reports/${BUNDLE_PLATFORM}"
+        mkdir -p "$report_output"
+        cp "${BUILD_OUTPUT}"/junit-report*.xml "$report_output"
+        echo "::set-output name=report-output::${report_output}"
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: dockerd-test-results
+        path: ${{ steps.copy-test-results.outputs.report-output }}
+        retention-days: 7
+
+  publish-test-results:
+    runs-on: ubuntu-latest
+    needs: 
+      - unit-test
+    # unit-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+    - name: Download test results
+      uses: actions/download-artifact@v2
+      with:
+        name: dockerd-test-results
+        path: bundles/junit-reports
+
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      with:
+        deduplicate_classes_by_file_name: true
+        files: bundles/junit-reports/**/junit-report*.xml
+    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,11 +180,22 @@ jobs:
         build-output: ${{ env.BUILD_OUTPUT }}
 
     - name: Download docker cli
+      id: download-docker-cli
       uses: WAGO/docker-actions/download-release-asset@release/v1.0
       with:
         repository: WAGO/docker-cli
         token: ${{ secrets.GITHUB_TOKEN }}
-        download-url-filter: ${{ steps.docker-make.outputs.target-platform-id }}
+        url-filterpattern: docker-cli-.*static.*-${{ steps.docker-make.outputs.target-platform-id }}[.]tar[.]gz
+        working-directory: ${{ env.BUILD_OUTPUT }} 
+
+    - name: Extract docker cli
+      id: extract-docker-cli
+      env:
+        DOWNLOAD_PATH: ${{ steps.download-docker-cli.outputs.root-path }}
+      run: |
+        build_output="${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${build_output}" -xzvf "${DOWNLOAD_PATH}/docker-cli-"*"static"*".tar.gz"
+        echo "::set-output name=path::${build_output}"
 
     - name: Create bundle
       id: create-bundle
@@ -193,8 +204,7 @@ jobs:
       run: |
         bundle_archive_name="docker-static-${BUNDLE_PLATFORM}.tar"
         bundle_archive="${BUILD_OUTPUT}/${bundle_archive_name}"
-        build_output="${BUILD_OUTPUT}/binary-daemon"
-        tar -C "${build_output}" -xzvf "docker-cli-"*".tar.gz"
+        build_output="${{ steps.extract-docker-cli.outputs.path }}"
         tar -C "${build_output}" -cvf "${bundle_archive}" .
         echo "::set-output name=input-path::${build_output}"
         echo "::set-output name=archive::${bundle_archive}"
@@ -214,6 +224,7 @@ jobs:
         "${BUNDLE_INPUT_PATH}/runc" --version
         "${BUNDLE_INPUT_PATH}/containerd" --version
         "${BUNDLE_INPUT_PATH}/dockerd" --version
+        "${BUNDLE_INPUT_PATH}/docker" version
 
   build-dynamic-binary:
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,227 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+env:
+  PLATFORM: Docker Engine - WAGO (Community)
+  DEFAULT_PRODUCT_LICENSE: Community Engine
+  DOCKER_GITCOMMIT: ${{ github.sha }}
+  DOCKER_EXPERIMENTAL: 1
+  DOCKER_GRAPHDRIVER: overlay2
+  BUILDKIT_PROGRESS: plain
+  BASE_DEBIAN_DISTRO: stretch
+  GO_VERSION: 1.16.7
+  APT_MIRROR: cdn-fastly.deb.debian.org
+  CHECK_CONFIG_COMMIT: 78405559cfe5987174aa2cb6463b9b2c1b917255
+  TESTDEBUG: 0
+  TIMEOUT: 120m
+  BUILD_OUTPUT: bundles
+  VERSION: '20.10-dev'
+  DOCKER_CLI_REPOSITORY: WAGO/docker-cli
+  DOCKER_CLI_TAG: latest
+
+jobs:
+  check:
+    runs-on: ubuntu-18.04
+    
+    outputs:
+      stringver: ${{ steps.contentrel.outputs.stringver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Check signature
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          tagcheck=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          echo "${tagcheck}" | grep -q "error" && {
+              echo "::error::tag ${releasever} is not a signed tag. Failing release process."
+              exit 1
+          } || {
+              echo "Tag ${releasever} is signed."
+              exit 0
+          }
+
+      - name: Release content
+        id: contentrel
+        run: |
+          releasever=${{ github.ref }}
+          echo "::set-output name=stringver::${releasever#refs/tags/v}"
+
+          file_path="${BUILD_OUTPUT}"/release-notes.md
+          echo "::set-output name=path::${file_path}"
+
+          mkdir -p "${BUILD_OUTPUT}"
+          git tag -l ${releasever#refs/tags/} -n20000 | tail -n +3 | cut -c 5- > "${file_path}"
+
+      - name: Save release notes
+        uses: actions/upload-artifact@v2
+        with:
+          name: dockerd-release-notes
+          path: ${{ steps.contentrel.outputs.path }}
+
+  build-static-binary:
+  
+    strategy:
+      matrix:
+        include:
+        - arch: amd64
+          platform: linux/amd64
+        - arch: arm32v7
+          platform: linux/arm/v7
+      
+    runs-on: ubuntu-18.04
+    needs:
+      - check
+      - fetch-docker-cli-release
+
+    env:
+      VERSION: ${{ needs.check.outputs.stringver }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Make binary
+      id: docker-make
+      uses: WAGO/docker-actions/docker-make@release/v1.0
+      with:
+        targets: |
+          binary
+        golang-version: ${{ env.GO_VERSION }}
+        base-debian-distro: ${{ env.BASE_DEBIAN_DISTRO }}
+        host-arch: ${{ matrix.arch }}
+        target-platform: ${{ matrix.platform }}
+        check-config-commit: ${{ env.CHECK_CONFIG_COMMIT }}
+        project-version: ${{ env.VERSION }}
+        build-output: ${{ env.BUILD_OUTPUT }}
+        buildx-build-args: |
+          --build-arg SOURCE_DATE_EPOCH
+          --build-arg BUILDTIME
+
+    - name: Create bundle
+      id: create-bundle
+      env:
+        BUNDLE_PLATFORM: ${{ steps.setup-docker-make.outputs.target-platform-id }}
+        VERSION: ${{ steps.setup-docker-make.outputs.version }}
+      run: |
+        bundle_archive_name="docker-${VERSION//\./_}_static-${BUNDLE_PLATFORM}.tar"
+        bundle_archive_base="${BUILD_OUTPUT}/${bundle_archive_name}"
+        bundle_archive="${bundle_archive_base}.gz"
+        build_output="${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${build_output}" -czvf "${bundle_archive}" .
+        (cd "$(dirname "${bundle_archive}")"; sha256sum "$(basename "${bundle_archive}")") > "${bundle_archive}".sha256sum
+        echo "::set-output name=archive-base::${bundle_archive_base}"
+        echo "::set-output name=input-path::${build_output}"
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: docker-bundles
+        path: ${{ steps.create-bundle.outputs.archive-base }}.*
+        retention-days: 7
+
+    - name: Print artifact version informations
+      env:
+        BUNDLE_INPUT_PATH: ${{ steps.create-bundle.outputs.input-path }}
+      run: |
+        "${BUNDLE_INPUT_PATH}/runc" --version
+        "${BUNDLE_INPUT_PATH}/containerd" --version
+        "${BUNDLE_INPUT_PATH}/dockerd" --version
+
+  release:
+    runs-on: ubuntu-18.04
+
+    needs: 
+      - build-static-binary
+      - check
+
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+
+    steps:
+      - name: Download Release notes
+        uses: actions/download-artifact@v2
+        with:
+          name: dockerd-release-notes
+          path: ${{ env.BUILD_OUTPUT }}
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1.1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: docker ${{ needs.check.outputs.stringver }}
+          body_path: ${{ env.BUILD_OUTPUT }}/release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+
+  release-upload:
+    runs-on: ubuntu-18.04
+
+    needs:
+      - release
+
+    steps:
+    - name: Download bundles
+      uses: actions/download-artifact@v2
+      with:
+        name: docker-bundles
+        path: ${{ env.BUILD_OUTPUT }}
+          
+    - name: Create catalog
+      id: catalog
+      run: |
+        _filenum=1
+        for f in $(ls "docker-"*); do
+          echo "::set-output name=file${_filenum}::${f}"
+          let _filenum+=1
+        done
+      working-directory: ${{ env.BUILD_OUTPUT }}
+      shell: bash
+
+    - name: 1st Upload tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.BUILD_OUTPUT }}/${{ steps.catalog.outputs.file1 }}
+        asset_name: ${{ steps.catalog.outputs.file1 }}
+        asset_content_type: application/gzip
+    - name: 1st Upload sha256 sum
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.BUILD_OUTPUT }}/${{ steps.catalog.outputs.file2 }}
+        asset_name: ${{ steps.catalog.outputs.file2 }}
+        asset_content_type: text/plain
+
+    - name: 2nd Upload tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.BUILD_OUTPUT }}/${{ steps.catalog.outputs.file3 }}
+        asset_name: ${{ steps.catalog.outputs.file3 }}
+        asset_content_type: application/gzip
+    - name: 2nd Upload sha256 sum
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.BUILD_OUTPUT }}/${{ steps.catalog.outputs.file4 }}
+        asset_name: ${{ steps.catalog.outputs.file4 }}
+        asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ env:
   TESTDEBUG: 0
   TIMEOUT: 120m
   BUILD_OUTPUT: bundles
-  VERSION: '20.10-dev'
-  DOCKER_CLI_REPOSITORY: WAGO/docker-cli
-  DOCKER_CLI_TAG: latest
+  VERSION: 20.10-dev
 
 jobs:
   check:
@@ -80,7 +78,6 @@ jobs:
     runs-on: ubuntu-18.04
     needs:
       - check
-      - fetch-docker-cli-release
 
     env:
       VERSION: ${{ needs.check.outputs.stringver }}
@@ -106,16 +103,33 @@ jobs:
           --build-arg SOURCE_DATE_EPOCH
           --build-arg BUILDTIME
 
+    - name: Download docker cli
+      id: download-docker-cli
+      uses: WAGO/docker-actions/download-release-asset@release/v1.0
+      with:
+        repository: WAGO/docker-cli
+        token: ${{ secrets.GITHUB_TOKEN }}
+        url-filterpattern: docker-cli-.*static.*-${{ steps.docker-make.outputs.target-platform-id }}[.]tar[.]gz
+        working-directory: ${{ env.BUILD_OUTPUT }} 
+
+    - name: Extract docker cli
+      id: extract-docker-cli
+      env:
+        DOWNLOAD_PATH: ${{ steps.download-docker-cli.outputs.root-path }}
+      run: |
+        build_output="${BUILD_OUTPUT}/binary-daemon"
+        tar -C "${build_output}" -xzvf "${DOWNLOAD_PATH}/docker-cli-"*"static"*".tar.gz"
+        echo "::set-output name=path::${build_output}"
+
     - name: Create bundle
       id: create-bundle
       env:
-        BUNDLE_PLATFORM: ${{ steps.setup-docker-make.outputs.target-platform-id }}
-        VERSION: ${{ steps.setup-docker-make.outputs.version }}
+        BUNDLE_PLATFORM: ${{ steps.docker-make.outputs.target-platform-id }}
       run: |
         bundle_archive_name="docker-${VERSION//\./_}_static-${BUNDLE_PLATFORM}.tar"
         bundle_archive_base="${BUILD_OUTPUT}/${bundle_archive_name}"
         bundle_archive="${bundle_archive_base}.gz"
-        build_output="${BUILD_OUTPUT}/binary-daemon"
+        build_output="${{ steps.extract-docker-cli.outputs.path }}"
         tar -C "${build_output}" -czvf "${bundle_archive}" .
         (cd "$(dirname "${bundle_archive}")"; sha256sum "$(basename "${bundle_archive}")") > "${bundle_archive}".sha256sum
         echo "::set-output name=archive-base::${bundle_archive_base}"
@@ -135,6 +149,7 @@ jobs:
         "${BUNDLE_INPUT_PATH}/runc" --version
         "${BUNDLE_INPUT_PATH}/containerd" --version
         "${BUNDLE_INPUT_PATH}/dockerd" --version
+        "${BUNDLE_INPUT_PATH}/docker" version
 
   release:
     runs-on: ubuntu-18.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG VPNKIT_VERSION=0.5.0
 ARG DOCKER_BUILDTAGS="apparmor seccomp"
 
-ARG BASE_DEBIAN_DISTRO="buster"
+ARG BASE_DEBIAN_DISTRO="stretch"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 
 FROM ${GOLANG_IMAGE} AS base
@@ -167,6 +167,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS containerd
 ARG DEBIAN_FRONTEND
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-containerd-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -31,11 +31,6 @@ _install_rootlesskit() (
 	cd "$GOPATH/src/github.com/rootless-containers/rootlesskit" || exit 1
 	git checkout -q "$ROOTLESSKIT_COMMIT"
 	export GO111MODULE=on
-	# TODO remove GOPROXY override once we updated to Go 1.14+
-	# Using goproxy instead of "direct" to work around an issue in go mod
-	# on Go 1.13 not working with older git versions (default version on
-	# CentOS 7 is git 1.8), see https://github.com/golang/go/issues/38373
-	export GOPROXY="https://proxy.golang.org"
 	for f in rootlesskit rootlesskit-docker-proxy; do
 		go build $BUILD_MODE -ldflags="$ROOTLESSKIT_LDFLAGS" -o "${PREFIX}/$f" github.com/rootless-containers/rootlesskit/cmd/$f
 	done


### PR DESCRIPTION
Add main CI workflow based on github actions

build docker engine for:
- amd64
- armv7

on pull-request for release/v20.10-wago